### PR TITLE
[feat] localStorage 제거 및 인증 기반 채팅 연동

### DIFF
--- a/src/components/chatting/ChatHeader.tsx
+++ b/src/components/chatting/ChatHeader.tsx
@@ -6,16 +6,14 @@ interface ChatHeaderProps {
   otherUser?: string;
   onBackToList: () => void;
   roomId: number;
-  currentUserId: number;
-  currentUserNickname: string;
+  userId: number;
 }
 
 const ChatHeader = ({
   otherUser,
   onBackToList,
   roomId,
-  currentUserId,
-  currentUserNickname,
+  userId,
 }: ChatHeaderProps) => {
   const [isBellOff, setBellOff] = useState(true);
   const [isSidebarOpen, setSidebarOpen] = useState(false);
@@ -33,7 +31,7 @@ const ChatHeader = ({
           <ArrowLeft />
         </button>
         <p className="absolute left-1/2 transform -translate-x-1/2">
-          {otherUser ?? '채팅방'}
+          {otherUser ?? ''}
         </p>
         <div className="flex space-x-4 ml-auto">
           <button
@@ -51,8 +49,7 @@ const ChatHeader = ({
         isOpen={isSidebarOpen}
         onClose={() => setSidebarOpen(false)}
         roomId={roomId}
-        currentUserId={currentUserId}
-        currentUserNickname={currentUserNickname}
+        userId={userId}
       />
     </>
   );

--- a/src/components/chatting/ChatInput.tsx
+++ b/src/components/chatting/ChatInput.tsx
@@ -8,10 +8,10 @@ import { useChatListStore } from '@/stores/useChatListStore';
 interface ChatInputProps {
   roomId: number;
   socketRef: { current: Client | null };
-  currentUser: string | null;
+  nickName: string;
 }
 
-const ChatInput = ({ roomId, socketRef, currentUser }: ChatInputProps) => {
+const ChatInput = ({ roomId, socketRef, nickName }: ChatInputProps) => {
   const [message, setMessage] = useState('');
   const maxLength = 1000;
 
@@ -19,7 +19,7 @@ const ChatInput = ({ roomId, socketRef, currentUser }: ChatInputProps) => {
   const { updateLastMessage } = useChatListStore();
 
   const handleSend = () => {
-    if (!socketRef.current || !socketRef.current.connected || !currentUser) {
+    if (!socketRef.current || !socketRef.current.connected || !nickName) {
       return;
     }
     const trimmed = message.trim();
@@ -29,7 +29,7 @@ const ChatInput = ({ roomId, socketRef, currentUser }: ChatInputProps) => {
     const chatMessage: ChatMessageType = {
       messageId: Date.now(),
       roomId,
-      senderNickname: currentUser,
+      senderNickname: nickName,
       content: trimmed,
       timeStamp: new Date().toISOString(),
       type: 'CHAT',

--- a/src/components/chatting/ChatMessageItem.tsx
+++ b/src/components/chatting/ChatMessageItem.tsx
@@ -6,13 +6,13 @@ import { formatTime } from '@/utils/chat/formatTime';
 interface ChatMessageItemProps {
   roomId: number;
   chatParticipants: string[];
-  currentUser: string | null;
+  nickName: string;
 }
 
 const ChatMessageItem = ({
   roomId,
   //chatParticipants,
-  currentUser,
+  nickName,
 }: ChatMessageItemProps) => {
   const rawMessages = useChatMessageStore(
     (state) => state.messagesByRoom[roomId],
@@ -24,7 +24,7 @@ const ChatMessageItem = ({
   return (
     <>
       {messages.map((msg, index) => {
-        const isMyMessage = msg.senderNickname === currentUser;
+        const isMyMessage = msg.senderNickname === nickName;
 
         const isJoin = msg.type === 'JOIN';
         const isLeave = msg.type === 'LEAVE';

--- a/src/components/chatting/ChatRoom.tsx
+++ b/src/components/chatting/ChatRoom.tsx
@@ -6,6 +6,7 @@ import ChatInput from '@/components/chatting/ChatInput';
 import ChatMessageItem from '@/components/chatting/ChatMessageItem';
 import { ChatRoomType } from '@/types/chatRoomType';
 import { useChatListStore } from '@/stores/useChatListStore';
+import { useChatMyInfo } from '@/stores/useChatMyInfoStore';
 import { fetchMessagesApi } from '@/services/chatMessageApi';
 
 interface ChatRoomProps {
@@ -14,19 +15,17 @@ interface ChatRoomProps {
 
 const ChatRoom = ({ room }: ChatRoomProps) => {
   const { stompClient } = useSocketStore();
-  const clientId = localStorage.getItem('userId');
-  const currentUser = localStorage.getItem('userNickname');
-
+  const { userId, nickName } = useChatMyInfo();
   const { appendMessage, setMessages, clearMessages } = useChatMessageStore();
   const { updateLastMessage } = useChatListStore();
 
   // 이전 메시지 불러오기
   useEffect(() => {
-    if (!room || !clientId) return;
+    if (!room || !userId) return;
 
     const fetchMessages = async () => {
       try {
-        const messages = await fetchMessagesApi(room.roomId, Number(clientId));
+        const messages = await fetchMessagesApi(room.roomId, Number(userId));
         setMessages(room.roomId, messages);
       } catch (error) {
         console.error('메시지 불러오기 실패', error);
@@ -34,7 +33,7 @@ const ChatRoom = ({ room }: ChatRoomProps) => {
     };
 
     fetchMessages();
-  }, [room?.roomId, clientId, setMessages]);
+  }, [room?.roomId, userId, setMessages]);
 
   useEffect(() => {
     if (!room || !stompClient || !stompClient.connected) return;
@@ -79,13 +78,13 @@ const ChatRoom = ({ room }: ChatRoomProps) => {
           <ChatMessageItem
             roomId={room.roomId}
             chatParticipants={room.participants}
-            currentUser={localStorage.getItem('userNickname')}
+            nickName={nickName ?? ''}
           />
         </div>
       </div>
       <ChatInput
         roomId={room.roomId}
-        currentUser={currentUser}
+        nickName={nickName ?? ''}
         socketRef={{ current: stompClient }}
       />
     </>

--- a/src/components/chatting/ChatSideBar.tsx
+++ b/src/components/chatting/ChatSideBar.tsx
@@ -9,17 +9,10 @@ interface ChatSideBarProps {
   isOpen: boolean;
   onClose: () => void;
   roomId: number;
-  currentUserId: number;
-  currentUserNickname: string;
+  userId: number;
 }
 
-const ChatSideBar = ({
-  isOpen,
-  onClose,
-  roomId,
-  currentUserId,
-  //  currentUserNickname,
-}: ChatSideBarProps) => {
+const ChatSideBar = ({ isOpen, onClose, roomId, userId }: ChatSideBarProps) => {
   const queryClient = useQueryClient();
   const { disconnect } = useSocketStore.getState();
   const { removeChatRoom } = useChatListStore();
@@ -59,7 +52,7 @@ const ChatSideBar = ({
       // 서버에 퇴장 요청
       await api.post('/api/chat/exit', {
         roomId,
-        clientId: currentUserId,
+        clientId: userId,
       });
       // console.log('API 응답:', response);
       // console.log('응답 상태 코드:', response.status);
@@ -68,10 +61,10 @@ const ChatSideBar = ({
       removeChatRoom(roomId);
 
       queryClient.invalidateQueries({
-        queryKey: ['chatSentList', currentUserId ?? '', 'ACCEPTED'],
+        queryKey: ['chatSentList', userId ?? '', 'ACCEPTED'],
       });
       queryClient.invalidateQueries({
-        queryKey: ['chatReceivedList', currentUserId ?? '', 'ACCEPTED'],
+        queryKey: ['chatReceivedList', userId ?? '', 'ACCEPTED'],
       });
 
       disconnect();

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -1,0 +1,7 @@
+import { api } from '@/utils/api';
+
+export const fetchAuthApi = async () => {
+  const { data } = await api.get('/auth/me');
+
+  return data;
+};

--- a/src/stores/useChatMyInfoStore.ts
+++ b/src/stores/useChatMyInfoStore.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchAuthApi } from '@/services/authApi';
+import { fetchUserProfileApi } from '@/services/userProfileApi';
+
+export const useChatMyInfo = () => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['useChatMyInfo'],
+    queryFn: async () => {
+      const { id } = await fetchAuthApi();
+      const profile = await fetchUserProfileApi(id);
+      return {
+        id: profile.id,
+        nickName: profile.nickName,
+      };
+    },
+  });
+
+  return {
+    userId: data?.id,
+    nickName: data?.nickName,
+    isLoading,
+    isError,
+  };
+};

--- a/src/types/userProfileType.ts
+++ b/src/types/userProfileType.ts
@@ -1,9 +1,6 @@
 export interface UserProfileType {
   id: number;
   nickName: string;
-  role: string;
-  profileImage: string;
-  topic1: 'string';
-  topic2: 'string';
-  topic3: 'string';
+  role?: string;
+  profileImage?: string;
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,8 +2,9 @@ import axios from 'axios';
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_BASE_API_URL,
+  withCredentials: true,
   headers: {
-    'Content-Type': 'application/json; charset=UTF-8;',
+    'Content-Type': 'application/json',
     accept: 'application/json',
   },
 });


### PR DESCRIPTION
## Summary

>- closes #43 

## Tasks
- 기존 채팅 페이지에서 사용자 정보를 localStorage로 테스트하던 방식을 제거합니다.
- 로그인된 사용자 정보를 불러오도록 변경합니다.

## To Reviewer

테스트를 위한 작업입니다. 문제없다면 우선 이대로 진행하겠습니다.


