### PR TITLE
[feat] 채팅 장문 메세지 전송시 전체 보기 기능

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^19.0.0",
     "react-feather": "^2.0.10",
     "react-router-dom": "^7.2.0",
+    "react-textarea-autosize": "^8.5.9",
     "react-toastify": "^11.0.5",
     "sockjs-client": "^1.6.1",
     "zustand": "^5.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-router-dom:
         specifier: ^7.2.0
         version: 7.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-textarea-autosize:
+        specifier: ^8.5.9
+        version: 8.5.9(@types/react@19.0.12)(react@19.0.0)
       react-toastify:
         specifier: ^11.0.5
         version: 11.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -206,6 +209,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.27.0':
+    resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.26.9':
     resolution: {integrity: sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==}
@@ -1713,6 +1720,12 @@ packages:
       react-dom:
         optional: true
 
+  react-textarea-autosize@8.5.9:
+    resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-toastify@11.0.5:
     resolution: {integrity: sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==}
     peerDependencies:
@@ -1733,6 +1746,9 @@ packages:
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -2000,6 +2016,33 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  use-composed-ref@1.4.0:
+    resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-isomorphic-layout-effect@1.2.0:
+    resolution: {integrity: sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest@1.3.0:
+    resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -2217,6 +2260,10 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/runtime@7.27.0':
+    dependencies:
+      regenerator-runtime: 0.14.1
 
   '@babel/template@7.26.9':
     dependencies:
@@ -3761,6 +3808,15 @@ snapshots:
     optionalDependencies:
       react-dom: 19.0.0(react@19.0.0)
 
+  react-textarea-autosize@8.5.9(@types/react@19.0.12)(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.27.0
+      react: 19.0.0
+      use-composed-ref: 1.4.0(@types/react@19.0.12)(react@19.0.0)
+      use-latest: 1.3.0(@types/react@19.0.12)(react@19.0.0)
+    transitivePeerDependencies:
+      - '@types/react'
+
   react-toastify@11.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       clsx: 2.1.1
@@ -3787,6 +3843,8 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  regenerator-runtime@0.14.1: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -4163,6 +4221,25 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-composed-ref@1.4.0(@types/react@19.0.12)(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.12
+
+  use-isomorphic-layout-effect@1.2.0(@types/react@19.0.12)(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.12
+
+  use-latest@1.3.0(@types/react@19.0.12)(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      use-isomorphic-layout-effect: 1.2.0(@types/react@19.0.12)(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.12
 
   util-deprecate@1.0.2: {}
 

--- a/src/components/chatting/ChatBubble.tsx
+++ b/src/components/chatting/ChatBubble.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronRight } from 'react-feather';
+
+interface ChatBubbleProps {
+  content: string;
+  isMyMessage: boolean;
+}
+
+const MAX_HEIGHT = 136;
+
+const ChatBubble = ({ content, isMyMessage }: ChatBubbleProps) => {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      const scrollHei = contentRef.current.scrollHeight;
+
+      if (scrollHei > MAX_HEIGHT) setIsOverflowing(true);
+    }
+  }, [content]);
+
+  return (
+    <>
+      <div
+        ref={contentRef}
+        className={`
+      inline-block p-2 px-4 break-all leading-normal max-h-[133px]
+      overflow-hidden whitespace-pre-line break-words text-white
+      ${
+        isMyMessage
+          ? `bg-point-blue self-end rounded-tl-lg rounded-tr-lg ${
+              isOverflowing ? '' : 'rounded-bl-lg rounded-br-none'
+            }`
+          : `bg-[#141415] self-start rounded-tl-lg rounded-tr-lg ${
+              isOverflowing ? '' : 'rounded-bl-none rounded-br-lg'
+            }`
+      }
+    `}>
+        {content}
+      </div>
+      {isOverflowing && (
+        <button
+          type="button"
+          className={`flex items-center justify-center w-full py-[9px] text-white text-sm
+        ${
+          isMyMessage
+            ? 'bg-point-blue self-end rounded-bl-lg rounded-br-none border-t border-t-[#2C7DF6]'
+            : 'bg-[#141415] self-start rounded-bl-none rounded-br-lg border-t border-t-[#222325]'
+        }
+      `}>
+          <span>전체보기</span>
+          <ChevronRight size={14} className="ml-1" />
+        </button>
+      )}
+    </>
+  );
+};
+
+export default ChatBubble;

--- a/src/components/chatting/ChatBubble.tsx
+++ b/src/components/chatting/ChatBubble.tsx
@@ -4,11 +4,12 @@ import { ChevronRight } from 'react-feather';
 interface ChatBubbleProps {
   content: string;
   isMyMessage: boolean;
+  onExpand?: (content: string) => void;
 }
 
 const MAX_HEIGHT = 136;
 
-const ChatBubble = ({ content, isMyMessage }: ChatBubbleProps) => {
+const ChatBubble = ({ content, isMyMessage, onExpand }: ChatBubbleProps) => {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
 
@@ -43,6 +44,7 @@ const ChatBubble = ({ content, isMyMessage }: ChatBubbleProps) => {
       {isOverflowing && (
         <button
           type="button"
+          onClick={() => onExpand?.(content)}
           className={`flex items-center justify-center w-full py-[9px] text-white text-sm
         ${
           isMyMessage

--- a/src/components/chatting/ChatBubble.tsx
+++ b/src/components/chatting/ChatBubble.tsx
@@ -21,7 +21,8 @@ const ChatBubble = ({ content, isMyMessage }: ChatBubbleProps) => {
   }, [content]);
 
   return (
-    <>
+    <div
+      className={`flex flex-col ${isMyMessage ? 'ml-8 self-end' : 'mr-8 self-start'}`}>
       <div
         ref={contentRef}
         className={`
@@ -53,7 +54,7 @@ const ChatBubble = ({ content, isMyMessage }: ChatBubbleProps) => {
           <ChevronRight size={14} className="ml-1" />
         </button>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/chatting/ChatInput.tsx
+++ b/src/components/chatting/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 import { useChatMessageStore } from '@/stores/useChatMessageStore';
 import { ChatMessageType } from '@/types/chatMessageType';
@@ -17,6 +17,15 @@ const ChatInput = ({ roomId, socketRef, nickName }: ChatInputProps) => {
 
   const { appendMessage } = useChatMessageStore();
   const { updateLastMessage } = useChatListStore();
+
+  // 입력시 자동 높이 조절
+  const textarea = useRef<HTMLTextAreaElement | null>(null);
+  const handleResizeHei = () => {
+    if (textarea.current) {
+      textarea.current.style.height = 'auto';
+      textarea.current.style.height = `${textarea.current.scrollHeight}px`;
+    }
+  };
 
   const handleSend = () => {
     if (!socketRef.current || !socketRef.current.connected || !nickName) {
@@ -66,7 +75,8 @@ const ChatInput = ({ roomId, socketRef, nickName }: ChatInputProps) => {
     <div className="pb-[66px]">
       <div className="relative flex-shrink-0 w-full px-5 flex items-end">
         <textarea
-          className={`w-full py-2 px-5 rounded-[20px] resize-none scrollbar-hide text-[#E6E6E6] text-sm placeholder-[#A2A4AA] bg-[#1E1E1F] border ${
+          ref={textarea}
+          className={`w-full py-2 px-5 max-h-[97.5px] rounded-[20px] resize-none scrollbar-hide text-[#E6E6E6] text-sm leading-normal placeholder-[#A2A4AA] bg-[#1E1E1F] border ${
             message.length > maxLength
               ? 'border-[#FF2B2B] focus:border-[#FF2B2B]'
               : 'border-[#1E1E1F]'
@@ -76,6 +86,7 @@ const ChatInput = ({ roomId, socketRef, nickName }: ChatInputProps) => {
           value={message}
           rows={1}
           onChange={(e) => setMessage(e.target.value)}
+          onInput={handleResizeHei}
           onKeyDown={onKeyDown}
           onKeyUp={onKeyUp}
         />

--- a/src/components/chatting/ChatInput.tsx
+++ b/src/components/chatting/ChatInput.tsx
@@ -55,6 +55,10 @@ const ChatInput = ({ roomId, socketRef, nickName }: ChatInputProps) => {
     updateLastMessage(roomId, chatMessage);
 
     setMessage('');
+
+    if (textarea.current) {
+      textarea.current.style.height = 'auto';
+    }
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/src/components/chatting/ChatMessageItem.tsx
+++ b/src/components/chatting/ChatMessageItem.tsx
@@ -3,17 +3,20 @@ import { useChatMessageStore } from '@/stores/useChatMessageStore';
 import { formatTime } from '@/utils/chat/formatTime';
 import Button from '@/components/common/Button';
 import { LogOut } from 'react-feather';
+import { motion } from 'framer-motion';
 
 interface ChatMessageItemProps {
   roomId: number;
   chatParticipants: string[];
   nickName: string;
+  onExpand?: (content: string) => void;
 }
 
 const ChatMessageItem = ({
   roomId,
   chatParticipants,
   nickName,
+  onExpand,
 }: ChatMessageItemProps) => {
   const rawMessages = useChatMessageStore(
     (state) => state.messagesByRoom[roomId],
@@ -65,12 +68,21 @@ const ChatMessageItem = ({
             <div
               className={`flex ${isMyMessage ? 'justify-end' : 'justify-start'}`}>
               <div className="flex flex-col max-w-[640px]">
-                <ChatBubble content={msg.content} isMyMessage={isMyMessage} />
-                {msg.timeStamp && (
-                  <p className="my-2 text-[#A2A4AA] text-right text-xs">
-                    {formatTime(msg.timeStamp)}
-                  </p>
-                )}
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.2 }}>
+                  <ChatBubble
+                    content={msg.content}
+                    isMyMessage={isMyMessage}
+                    onExpand={onExpand}
+                  />
+                  {msg.timeStamp && (
+                    <p className="my-2 text-[#A2A4AA] text-right text-xs">
+                      {formatTime(msg.timeStamp)}
+                    </p>
+                  )}
+                </motion.div>
               </div>
             </div>
           </div>

--- a/src/components/chatting/ChatMessageItem.tsx
+++ b/src/components/chatting/ChatMessageItem.tsx
@@ -1,7 +1,8 @@
+import ChatBubble from '@/components/chatting/ChatBubble';
 import { useChatMessageStore } from '@/stores/useChatMessageStore';
 import { formatTime } from '@/utils/chat/formatTime';
-// import Button from '@/components/common/Button';
-// import { LogOut } from 'react-feather';
+import Button from '@/components/common/Button';
+import { LogOut } from 'react-feather';
 
 interface ChatMessageItemProps {
   roomId: number;
@@ -11,7 +12,7 @@ interface ChatMessageItemProps {
 
 const ChatMessageItem = ({
   roomId,
-  //chatParticipants,
+  chatParticipants,
   nickName,
 }: ChatMessageItemProps) => {
   const rawMessages = useChatMessageStore(
@@ -19,7 +20,9 @@ const ChatMessageItem = ({
   );
   const messages = rawMessages ?? [];
 
-  //const other = chatParticipants.find((nickname) => nickname !== currentUser);
+  const other = chatParticipants.find(
+    (userNickname) => userNickname !== nickName,
+  );
 
   return (
     <>
@@ -28,22 +31,21 @@ const ChatMessageItem = ({
 
         const isJoin = msg.type === 'JOIN';
         const isLeave = msg.type === 'LEAVE';
-        // if ((isJoin || isLeave) && isMyMessage) return null;
 
         if (isJoin || isLeave) {
-          //let displayText = msg.content;
+          let displayText = msg.content;
 
-          // if (isJoin && isMyMessage && other) {
-          //   displayText = `${other}님과의 대화가 시작되었어요.`;
-          // }
-          // if (isLeave && other) {
-          //   displayText = `${msg.senderNickname}님이 퇴장했습니다.`;
-          // }
+          if (isJoin && isMyMessage && other) {
+            displayText = `${other}님과의 대화가 시작되었어요.`;
+          }
+          if (isLeave && !isMyMessage && other) {
+            displayText = `${msg.senderNickname}님이 퇴장했습니다.`;
+          }
           return (
             <div
               key={index}
               className="mb-7 text-center text-sm font-medium text-[#A2A4AA]">
-              {/* <p>{displayText}</p>
+              <p>{displayText}</p>
               {isLeave && (
                 <Button
                   size="sm"
@@ -52,7 +54,7 @@ const ChatMessageItem = ({
                   className="m-auto mt-2">
                   이 채팅방 떠나기
                 </Button>
-              )} */}
+              )}
             </div>
           );
         }
@@ -63,16 +65,9 @@ const ChatMessageItem = ({
             <div
               className={`flex ${isMyMessage ? 'justify-end' : 'justify-start'}`}>
               <div className="flex flex-col max-w-[640px]">
-                <div
-                  className={`inline-block p-2 px-4 my-2 break-all leading-relaxed ${
-                    isMyMessage
-                      ? 'bg-point-blue text-white self-end rounded-br-none rounded-tl-lg rounded-tr-lg rounded-bl-lg'
-                      : 'bg-[#141415] text-white self-start rounded-bl-none rounded-tl-lg rounded-tr-lg rounded-br-lg'
-                  }`}>
-                  {msg.content}
-                </div>
+                <ChatBubble content={msg.content} isMyMessage={isMyMessage} />
                 {msg.timeStamp && (
-                  <p className="text-[#A2A4AA] text-right text-xs">
+                  <p className="my-2 text-[#A2A4AA] text-right text-xs">
                     {formatTime(msg.timeStamp)}
                   </p>
                 )}

--- a/src/components/chatting/ChatRoom.tsx
+++ b/src/components/chatting/ChatRoom.tsx
@@ -11,9 +11,10 @@ import { fetchMessagesApi } from '@/services/chatMessageApi';
 
 interface ChatRoomProps {
   room: ChatRoomType | null;
+  onExpandMessage?: (content: string) => void;
 }
 
-const ChatRoom = ({ room }: ChatRoomProps) => {
+const ChatRoom = ({ room, onExpandMessage }: ChatRoomProps) => {
   const { stompClient } = useSocketStore();
   const { userId, nickName } = useChatMyInfo();
   const { appendMessage, setMessages, clearMessages } = useChatMessageStore();
@@ -79,6 +80,7 @@ const ChatRoom = ({ room }: ChatRoomProps) => {
             roomId={room.roomId}
             chatParticipants={room.participants}
             nickName={nickName ?? ''}
+            onExpand={onExpandMessage}
           />
         </div>
       </div>

--- a/src/components/chatting/FullMessageViewer.tsx
+++ b/src/components/chatting/FullMessageViewer.tsx
@@ -1,0 +1,49 @@
+import { X } from 'react-feather';
+
+interface MessageViewerProps {
+  expandedMessage: string;
+  onClose: () => void;
+}
+
+const FullMessageViewer = ({
+  expandedMessage,
+  onClose,
+}: MessageViewerProps) => {
+  return (
+    <>
+      {/* pc */}
+      <div className="hidden desktop:flex w-[33.33%] h-full flex-col bg-[#1E1E1F]">
+        <div className="flex flex-shrink-0 h-[52px] px-5 items-center justify-between">
+          <p className="font-semibold">메시지 전체보기</p>
+          <button type="button" onClick={onClose}>
+            <X size={18}></X>
+          </button>
+        </div>
+        <div className="pt-2 pb-5 px-5 mb-5 h-full overflow-y-auto">
+          <div className="h-full font-medium text-sm leading-normal">
+            {expandedMessage}
+          </div>
+        </div>
+      </div>
+
+      {/* tablet, mobile */}
+      <div className="desktop:hidden fixed inset-0 bg-black bg-opacity-70 z-50 flex items-center justify-center px-5">
+        <div className="bg-[#1E1E1F] w-full max-w-[400px] max-h-[70%] rounded-lg overflow-hidden flex flex-col">
+          <div className="flex flex-shrink-0 h-[52px] px-5 items-center justify-between">
+            <p className="font-semibold">메시지 전체보기</p>
+            <button type="button" onClick={onClose}>
+              <X></X>
+            </button>
+          </div>
+          <div className="pt-2 pb-5 px-5 mb-5 h-full overflow-y-auto">
+            <div className="h-full font-medium text-sm leading-normal">
+              {expandedMessage}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FullMessageViewer;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -62,10 +62,6 @@ const ChatPage = () => {
   // 모바일: 뒤로가기 클릭 시
   const onBackToList = () => setSelectedRoom(null);
 
-  if (userId === undefined) {
-    return;
-  }
-
   if (isLoading || userId === undefined) {
     return (
       <div className="pt-10 text-center text-[#A2A4AA]">

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -78,12 +78,10 @@ const ChatPage = () => {
     <div className="max-w-[1440px] m-auto flex h-screen overflow-hidden">
       <div
         className={`
-    flex flex-col h-full
-    ${expandedMessage ? 'w-[33.33%]' : 'desktop:max-w-[400px] tablet:max-w-[320px]'}
-    flex-shrink-0 overflow-y-auto
-    border border-l-0 border-t-0 border-b-0 border-[#222325] bg-[#0A0A0B]
-    ${selectedRoom ? 'hidden tablet:flex' : 'flex w-full'}
-    ${expandedMessage ? 'hidden tablet:flex' : ''}
+    flex flex-col flex-shrink-0 h-full
+    ${expandedMessage ? 'hidden tablet: w-[33.33%]' : 'desktop:w-[320px]'}
+    ${selectedRoom ? 'hidden tablet:flex w-[320px] desktop:w-[400px]' : 'flex w-full'}
+     overflow-y-auto border border-[#222325] bg-[#0A0A0B]
   `}>
         <ChatFilter
           filter={{
@@ -102,9 +100,9 @@ const ChatPage = () => {
       </div>
       <div
         className={`
-    relative flex-auto flex-col
-    ${selectedRoom ? 'flex' : 'hidden tablet:flex'}
-    ${expandedMessage ? 'w-[33.33%]' : ''}
+    relative flex flex-col flex-auto
+    ${selectedRoom ? 'flex' : 'hidden tablet:flex flex-auto'}
+    ${expandedMessage ? 'tablet:w-[33.33%]' : ''}
   `}>
         <ChatHeader
           otherUser={otherUser}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -5,6 +5,7 @@ import ChatList from '@/components/chatting/ChatList';
 import ChatHeader from '@/components/chatting/ChatHeader';
 import ChatRoom from '@/components/chatting/ChatRoom';
 import ChatFilter from '@/components/chatting/ChatFilter';
+import FullMessageViewer from '@/components/chatting/FullMessageViewer';
 import { useChatListStore } from '@/stores/useChatListStore';
 import { useChatMyInfo } from '@/stores/useChatMyInfoStore';
 import { fetchChatListApi } from '@/services/chatListApi';
@@ -22,6 +23,9 @@ const ChatPage = () => {
   const { userId, nickName } = useChatMyInfo();
   const { chatList, selectedRoom, setSelectedRoom } = useChatListStore();
   const { connect, isConnected } = useSocketStore();
+
+  // 채팅 메시지 전체보기 상태
+  const [expandedMessage, setExpandedMessage] = useState<string | null>(null);
 
   // 채팅방 정렬 상태 저장
   const [selectedOption, setSelectedOption] = useState<ChatFilterOption>(
@@ -73,7 +77,14 @@ const ChatPage = () => {
   return (
     <div className="max-w-[1440px] m-auto flex h-screen overflow-hidden">
       <div
-        className={`flex flex-col w-full h-full desktop:max-w-[400px] tablet:max-w-[320px] flex-shrink-0 overflow-y-auto border border-l-0 border-t-0 border-b-0 border-[#222325] bg-[#0A0A0B] ${selectedRoom ? 'hidden tablet:flex' : 'flex'}`}>
+        className={`
+    flex flex-col h-full
+    ${expandedMessage ? 'w-[33.33%]' : 'desktop:max-w-[400px] tablet:max-w-[320px]'}
+    flex-shrink-0 overflow-y-auto
+    border border-l-0 border-t-0 border-b-0 border-[#222325] bg-[#0A0A0B]
+    ${selectedRoom ? 'hidden tablet:flex' : 'flex w-full'}
+    ${expandedMessage ? 'hidden tablet:flex' : ''}
+  `}>
         <ChatFilter
           filter={{
             options: filterOptions,
@@ -90,17 +101,29 @@ const ChatPage = () => {
         />
       </div>
       <div
-        className={`relative flex-auto flex-col ${
-          selectedRoom ? 'flex' : 'hidden tablet:flex'
-        }`}>
+        className={`
+    relative flex-auto flex-col
+    ${selectedRoom ? 'flex' : 'hidden tablet:flex'}
+    ${expandedMessage ? 'w-[33.33%]' : ''}
+  `}>
         <ChatHeader
           otherUser={otherUser}
           roomId={selectedRoom?.roomId ?? 0}
           userId={userId}
           onBackToList={onBackToList}
         />
-        <ChatRoom room={selectedRoom} />
+        <ChatRoom
+          room={selectedRoom}
+          onExpandMessage={(content) => setExpandedMessage(content)}
+        />
       </div>
+      {/* 메세지 전체보기 */}
+      {expandedMessage && (
+        <FullMessageViewer
+          expandedMessage={expandedMessage}
+          onClose={() => setExpandedMessage(null)}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -15,8 +15,6 @@ import { ChatRequestType } from '@/types/chatRequestType';
 import { UserProfileType } from '@/types/userProfileType';
 import { api } from '@/utils/api';
 
-// 임시
-
 // 사용자 정보 가져오기
 const fetchUsers = async () => {
   const response = await api.get('/api/client/profile/all');
@@ -26,8 +24,8 @@ const fetchUsers = async () => {
 const TestPage = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { sent, received } = useChatRequestStore();
   const { nickName, isLoading } = useChatMyInfo();
+  const { sent, received } = useChatRequestStore();
 
   useChatRequestFetch(nickName ?? '');
 

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -1,7 +1,6 @@
-import axios from 'axios';
+import { api } from '@/utils/api';
 
 export const fetchAuthApi = async () => {
-  const { data } = await axios.get('https://api.i-contacts.link/auth/me');
-  console.log(data);
+  const { data } = await api.get('/auth/me');
   return data;
 };


### PR DESCRIPTION
## Summary

>- closes #53 

채팅에서 긴 메시지가 전송될 경우, 말줄임 처리된 메시지를 클릭 시 전체 내용을 확인할 수 있는 기능을 추가합니다.
반응형 레이아웃에 따라 스크롤 확장 방식 또는 모달 팝업 형태로 대응합니다.

## Tasks
- 긴 메시지 전송 시, 전체보기 디자인 적용 (PC: 스크롤 확장 / 모바일·태블릿: 모달 형태)
- `<ChatMessageItem/>` 컴포넌트 세분화하여 구조 개선
- 메시지 전송 시 모션 효과 추가

## Screenshot
![스크린샷 2025-04-01 오전 6 48 51](https://github.com/user-attachments/assets/e95d31f6-2df8-46d3-948e-16bddfa3f947)
![스크린샷 2025-04-01 오전 6 48 58](https://github.com/user-attachments/assets/f7850a88-a2a8-441b-a1e8-3aa6adced3fe)
![스크린샷 2025-04-01 오전 6 49 07](https://github.com/user-attachments/assets/094535c6-a964-496d-bab8-7cd9020ef7c3)
