### PR TITLE
[feat] 채팅 유저 프로필 데이터 연동 및 버튼 상태 분기 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import TestPage from '@/pages/TestPage';
 import ProfileLayout from '@/pages/profile/layout/ProfileLayout.tsx';
 import LandingPage from '@/pages/LandingPage.tsx';
 import EditMyPage from '@/pages/EditMyPage.tsx';
+import ProfilePreviewPage from '@/pages/ProfilePreviewPage';
+
 export default function App() {
   return (
     <>
@@ -37,6 +39,10 @@ export default function App() {
           <Route path="/editmy" element={<EditMyPage />} />
           <Route path="/chat" element={<Chat />} />
           <Route path="/chatProfile" element={<ChatProfile />} />
+          <Route
+            path="/profilePreview/:otherId"
+            element={<ProfilePreviewPage />}
+          />
         </Routes>
         <ToastContainer
           position="top-right"

--- a/src/components/chatting/ChatProfileInfo.tsx
+++ b/src/components/chatting/ChatProfileInfo.tsx
@@ -30,7 +30,9 @@ const ChatProfileInfo = ({ otherId }: ChatProfileInfoProps) => {
       </div>
       <b className="mt-2 text-lg">{profile.nickName}</b>
       <p className="font-medium">{profile.role}</p>
-      <Link to="/" className="flex items-center mt-2 text-[#B7B9BD]">
+      <Link
+        to={`/profilePreview/${otherId}`}
+        className="flex items-center mt-2 text-[#B7B9BD]">
         프로필 보기
         <ChevronRight size={16} />
       </Link>

--- a/src/components/common/ProfileCard.tsx
+++ b/src/components/common/ProfileCard.tsx
@@ -34,6 +34,8 @@ const ProfileCard = ({
   profileImageUrl,
   userId,
   profileId,
+  chatButtonState,
+  onMoveChat,
 }: ProfileCardProps) => {
   const navigate = useNavigate();
   const isOwner = userId === profileId;
@@ -104,25 +106,20 @@ const ProfileCard = ({
       {!isOwner && (
         <div className="mt-10">
           {chatButtonState === 'CHATTED' && (
-            <Button className="" variant="secondary" disabled>
+            <Button variant="secondary" disabled>
               채팅 종료됨
             </Button>
           )}
           {chatButtonState === 'MOVE' && (
-            <Button className="mobile:mt-6 mt-1" onClick={onMoveChat}>
-              채팅방으로 이동하기
-            </Button>
+            <Button onClick={onMoveChat}>채팅방으로 이동하기</Button>
           )}
           {chatButtonState === 'WAITING' && (
-            <Button className="mobile:mt-6 mt-1" variant="secondary" disabled>
+            <Button variant="secondary" disabled>
               수락 대기중...
             </Button>
           )}
           {chatButtonState === 'REQUEST' && (
-            <Button
-              className="mobile:mt-6 mt-1"
-              icon={<MessageCircle size={20} />}
-              onClick={onChat}>
+            <Button icon={<MessageCircle size={20} />} onClick={onChat}>
               대화 요청하기
             </Button>
           )}

--- a/src/components/common/ProfileCard.tsx
+++ b/src/components/common/ProfileCard.tsx
@@ -19,6 +19,8 @@ interface ProfileCardProps {
   onChat?: () => void;
   userId?: number;
   profileId?: number;
+  chatButtonState?: 'CHATTED' | 'MOVE' | 'WAITING' | 'REQUEST';
+  onMoveChat?: () => void;
 }
 
 const ProfileCard = ({
@@ -99,17 +101,32 @@ const ProfileCard = ({
         </div>
       </div>
 
-
-
-
-      {/* ✅ 소유자일 경우 대화요청 버튼 숨기기 */}
       {!isOwner && (
-        <Button
-          className="mobile:mt-6 mt-1"
-          icon={<MessageCircle size={20} />}
-          onClick={onChat}>
-          대화 요청하기
-        </Button>
+        <div className="mt-10">
+          {chatButtonState === 'CHATTED' && (
+            <Button className="" variant="secondary" disabled>
+              채팅 종료됨
+            </Button>
+          )}
+          {chatButtonState === 'MOVE' && (
+            <Button className="mobile:mt-6 mt-1" onClick={onMoveChat}>
+              채팅방으로 이동하기
+            </Button>
+          )}
+          {chatButtonState === 'WAITING' && (
+            <Button className="mobile:mt-6 mt-1" variant="secondary" disabled>
+              수락 대기중...
+            </Button>
+          )}
+          {chatButtonState === 'REQUEST' && (
+            <Button
+              className="mobile:mt-6 mt-1"
+              icon={<MessageCircle size={20} />}
+              onClick={onChat}>
+              대화 요청하기
+            </Button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/pages/ProfilePreviewPage.tsx
+++ b/src/pages/ProfilePreviewPage.tsx
@@ -1,0 +1,43 @@
+import { useParams } from 'react-router-dom';
+import ProfileCard from '@/components/common/ProfileCard';
+import { useUserProfile } from '@/hooks/useUserProfile';
+
+const ProfilePreviewPage = () => {
+  const { otherId } = useParams<{ otherId: string }>();
+  const { profile, loading } = useUserProfile(Number(otherId));
+
+  if (!otherId)
+    return (
+      <div className="pt-10 text-center text-[#A2A4AA]">잘못된 접근입니다.</div>
+    );
+
+  if (loading || !profile)
+    return <div className="pt-10 text-center text-[#A2A4AA]">로딩 중...</div>;
+
+  return (
+    <div className="max-w-[1440px] m-auto">
+      <div className="relative max-w-[375px] m-auto mobile:p-10 p-5 rounded-[4px] text-sm border border-[#222325] bg-[#1E1E1F]">
+        <ProfileCard
+          name={profile.nickName}
+          job={profile.role ?? ''}
+          bio={profile.introduction ?? ''}
+          interests={
+            [profile.topic1, profile.topic2, profile.topic3].filter(
+              Boolean,
+            ) as string[]
+          }
+          career={profile.career ?? ''}
+          links={(profile.links ?? []).map((link) => ({
+            title: link.title,
+            url: link.link,
+          }))}
+          profileImageUrl={profile.profileImage}
+          profileId={profile.id}
+          onChat={() => console.log('대화 요청')}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ProfilePreviewPage;

--- a/src/types/userProfileType.ts
+++ b/src/types/userProfileType.ts
@@ -1,6 +1,17 @@
+export interface LinkItem {
+  title: string;
+  link: string;
+}
+
 export interface UserProfileType {
   id: number;
   nickName: string;
   role?: string;
   profileImage?: string;
+  introduction?: string;
+  topic1?: string;
+  topic2?: string;
+  topic3?: string;
+  career?: string;
+  links?: LinkItem[];
 }


### PR DESCRIPTION
## Summary

>- closes #97 

채팅 유저 프로필 화면의 데이터 연동 작업과 채팅 요청 상태에 따른 버튼 분기 처리 작업을 진행했습니다.

## Tasks
- 채팅 상대방 프로필 페이지 추가
- 채팅 상대방 프로필 데이터 연동 (`/profilePreview/:otherId`)
  - 상대방의 닉네임, 역할, 소개글, 관심사, 링크 등 표시
  - `useUserProfile` 훅을 통해 프로필 데이터 조회
- 기존 `TestPage`에 있던 로직을 재사용하여 상태 분기 처리
- 요청 전 상태에서는 동일하게 `대화 요청하기` 클릭 시 채팅 요청이 호출되도록 구현

## To Reviewer
- @yungan9 님이 작업한 `ProfileCard` 컴포넌트에 채팅 상태에 따라 버튼을 분기할 수 있도록 관련 props 추가했습니다.
머지하실 때 참고 부탁드립니다!
- 현재 테스트 환경에 따라 병합 이후 수정이 필요할 경우, 추가 수정 진행하겠습니다.🫡

