### PR TITLE
[design] 공통 레이아웃 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,4 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import Chat from '@/pages/ChatPage';
-import ChatProfile from '@/components/common/ChatProfile.tsx';
-
 import { ToastContainer } from 'react-toastify';
 import ChatPage from '@/pages/ChatPage';
 import LoginPage from '@/pages/profile/LoginPage.tsx';
@@ -17,33 +14,53 @@ import ProfileLayout from '@/pages/profile/layout/ProfileLayout.tsx';
 import LandingPage from '@/pages/LandingPage.tsx';
 import EditMyPage from '@/pages/EditMyPage.tsx';
 import ProfilePreviewPage from '@/pages/ProfilePreviewPage';
+import ChatProfile from '@/components/common/ChatProfile.tsx';
+import Layout from '@/components/layout/Layout';
+import LogoOnlyNav from '@/components/layout/headers/LogoOnlyNav';
+import CommonNav from '@/components/layout/headers/CommonNav';
+import BackNav from '@/components/layout/headers/BackNav';
 
 export default function App() {
   return (
     <>
       <Router>
         <Routes>
-          <Route path="login" element={<LoginPage />} />
-          <Route path="/chat" element={<ChatPage />} />
-          <Route path="/profile" element={<ProfileLayout />}>
-            <Route path="1" element={<ProfileImgPage />} />
-            <Route path="2" element={<ProfileInfoPage />} />
-            <Route path="3" element={<ProfileJobPage />} />
-            <Route path="4" element={<ProfileInterestPage />} />
-            <Route path="5" element={<ProfileLinkPage />} />
-            <Route path="6" element={<ProfileIntroPage />} />
-          </Route>
-          <Route path="/home" element={<LocationPage />} />
+          {/* 랜딩 페이지 */}
           <Route path="/" element={<LandingPage />} />
-          <Route path="/test" element={<TestPage />} />
-          <Route path="/editmy" element={<EditMyPage />} />
-          <Route path="/chat" element={<Chat />} />
-          <Route path="/chatProfile" element={<ChatProfile />} />
-          <Route
-            path="/profilePreview/:otherId"
-            element={<ProfilePreviewPage />}
-          />
+
+          {/* logo only Nav */}
+          <Route element={<Layout nav={<LogoOnlyNav />} />}>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/profile" element={<ProfileLayout />}>
+              <Route path="1" element={<ProfileImgPage />} />
+              <Route path="2" element={<ProfileInfoPage />} />
+              <Route path="3" element={<ProfileJobPage />} />
+              <Route path="4" element={<ProfileInterestPage />} />
+              <Route path="5" element={<ProfileLinkPage />} />
+              <Route path="6" element={<ProfileIntroPage />} />
+            </Route>
+          </Route>
+
+          {/* back Nav: title */}
+          <Route element={<Layout nav={<BackNav title="내 계정" />} />}>
+            <Route path="/editmy" element={<EditMyPage />} />
+          </Route>
+          <Route element={<Layout nav={<BackNav />} />}>
+            <Route
+              path="/profilePreview/:otherId"
+              element={<ProfilePreviewPage />}
+            />
+          </Route>
+
+          {/* default Nav */}
+          <Route element={<Layout nav={<CommonNav />} />}>
+            <Route path="/home" element={<LocationPage />} />
+            <Route path="/chatProfile" element={<ChatProfile />} />
+            <Route path="/chat" element={<ChatPage />} />
+            <Route path="/test" element={<TestPage />} />
+          </Route>
         </Routes>
+
         <ToastContainer
           position="top-right"
           autoClose={1500}

--- a/src/components/common/ChatProfile.tsx
+++ b/src/components/common/ChatProfile.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import ProfileCard from '@/components/common/ProfileCard';
-import CommonNav from '@/components/common/CommomNav.tsx';
+import CommonNav from '@/components/layout/headers/CommonNav';
 
 interface ProfileData {
   nickName: string;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from 'react-router-dom';
+
+const Layout = ({ nav }: { nav: React.ReactNode }) => {
+  return (
+    <>
+      <header className="fixed z-40 top-0 left-0 w-full h-[64px] flex items-center justify-between px-4 shrink-0 border-b border-[#1f1f1f] bg-[#000]">
+        {nav}
+      </header>
+      <div className="max-w-[1440px] m-auto pt-16">
+        <Outlet />
+      </div>
+    </>
+  );
+};
+
+export default Layout;

--- a/src/components/layout/headers/BackNav.tsx
+++ b/src/components/layout/headers/BackNav.tsx
@@ -1,0 +1,23 @@
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft } from 'react-feather';
+
+interface BackNavProps {
+  title?: string;
+}
+
+const BackNav = ({ title }: BackNavProps) => {
+  const navigate = useNavigate();
+
+  return (
+    <nav className="relative flex w-full max-w-[1440px] m-auto">
+      <button
+        onClick={() => navigate(-1)}
+        className="absolute left-0 top-1/2 w-8 h-8 -translate-y-1/2">
+        <ArrowLeft size={20} />
+      </button>
+      {title && <span className="text-[16px] font-bold m-auto">{title}</span>}
+    </nav>
+  );
+};
+
+export default BackNav;

--- a/src/components/layout/headers/CommonNav.tsx
+++ b/src/components/layout/headers/CommonNav.tsx
@@ -1,16 +1,17 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Send, User } from 'react-feather';
-import Logo from '@/assets/images/logo.svg'; // 로고 경로는 예시
+import Logo from '@/assets/images/logo.svg';
 
 const CommonNav = () => {
   const navigate = useNavigate();
 
   return (
-    <nav className="h-[64px] flex items-center justify-between px-4 shrink-0 border-b border-[#1f1f1f]">
-      <button onClick={() => navigate('/home')}>
-        <img src={Logo} alt="Logo" className="h-[40px]" />
-      </button>
-
+    <nav className="flex w-full max-w-[1440px] m-auto justify-between">
+      <h1 className="inline-block">
+        <Link to="/home" className="block w-full h-full">
+          <img src={Logo} alt="Logo" className="h-[40px]" />
+        </Link>
+      </h1>
       <div className="flex flex-row items-center gap-4">
         <button
           onClick={() => navigate('/chat')}

--- a/src/components/layout/headers/LogoOnlyNav.tsx
+++ b/src/components/layout/headers/LogoOnlyNav.tsx
@@ -1,0 +1,16 @@
+import { Link } from 'react-router-dom';
+import Logo from '@/assets/images/logo.svg';
+
+const LogoOnlyNav = () => {
+  return (
+    <nav className="flex">
+      <h1 className="inline-block">
+        <Link to="/login" className="block w-full h-full">
+          <img src={Logo} alt="Logo" className="h-[40px]" />
+        </Link>
+      </h1>
+    </nav>
+  );
+};
+
+export default LogoOnlyNav;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -75,7 +75,7 @@ const ChatPage = () => {
   }
 
   return (
-    <div className="max-w-[1440px] m-auto flex h-screen overflow-hidden">
+    <div className="flex h-screen overflow-hidden">
       <div
         className={`
     flex flex-col flex-shrink-0  h-full

--- a/src/pages/EditMyPage.tsx
+++ b/src/pages/EditMyPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft, Link2 } from 'react-feather';
-import { useNavigate } from 'react-router-dom';
+import { Link2 } from 'react-feather';
 import axios from 'axios';
 import { Edit3 } from 'react-feather';
 
@@ -17,7 +16,6 @@ interface ProfileData {
 }
 
 const EditMyPage = () => {
-  const navigate = useNavigate();
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [profileImage, setProfileImage] = useState<string | null>(null);
 
@@ -60,14 +58,6 @@ const EditMyPage = () => {
 
   return (
     <div className="max-w-md mx-auto p-6 text-white bg-[#0F0F10] min-h-screen">
-      <div className="relative text-center text-[16px] font-bold mb-4">
-        <button
-          onClick={() => navigate('/home')}
-          className="absolute left-0 top-1/2 -translate-y-1/2">
-          <ArrowLeft size={20} />
-        </button>
-        내 계정
-      </div>
       <div className="relative flex justify-center mb-6">
         <img
           src={profileImage || undefined}

--- a/src/pages/LocationPage.tsx
+++ b/src/pages/LocationPage.tsx
@@ -3,12 +3,10 @@ import BottomSheet from 'src/components/location/BottomSheet';
 // import LocationButton from 'src/components/location/LocationButton';
 import LocationNavBar from 'src/components/location/LocationNavBar';
 import RightSheet from '@/components/location/RightSheet';
-import CommonNav from '@/components/common/CommomNav.tsx';
 
 const LocationPage = () => {
   return (
     <div className="w-full min-h-screen bg-[#000000] flex flex-col">
-      <CommonNav />
       <div className="flex flex-col tablet:flex-row px-4 gap-4 flex-1">
         <div className="w-full tablet:w-1/2 flex flex-col gap-2">
           <LocationNavBar />

--- a/src/pages/ProfilePreviewPage.tsx
+++ b/src/pages/ProfilePreviewPage.tsx
@@ -65,30 +65,28 @@ const ProfilePreviewPage = () => {
     return <div className="pt-10 text-center text-[#A2A4AA]">로딩 중...</div>;
 
   return (
-    <div className="max-w-[1440px] m-auto">
-      <div className="relative max-w-[375px] m-auto mobile:p-10 p-5 rounded-[4px] text-sm border border-[#222325] bg-[#1E1E1F]">
-        <ProfileCard
-          name={profile.nickName}
-          job={profile.role ?? ''}
-          bio={profile.introduction ?? ''}
-          interests={
-            [profile.topic1, profile.topic2, profile.topic3].filter(
-              Boolean,
-            ) as string[]
-          }
-          career={profile.career ?? ''}
-          links={(profile.links ?? []).map((link) => ({
-            title: link.title,
-            url: link.link,
-          }))}
-          profileImageUrl={profile.profileImage}
-          userId={userId}
-          profileId={profile.id}
-          chatButtonState={chatButtonState}
-          onChat={() => onChatRequest(profile.nickName)}
-          onMoveChat={handleMoveChat}
-        />
-      </div>
+    <div className="relative max-w-[375px] m-auto mobile:p-10 p-5 rounded-[4px] text-sm border border-[#222325] bg-[#1E1E1F]">
+      <ProfileCard
+        name={profile.nickName}
+        job={profile.role ?? ''}
+        bio={profile.introduction ?? ''}
+        interests={
+          [profile.topic1, profile.topic2, profile.topic3].filter(
+            Boolean,
+          ) as string[]
+        }
+        career={profile.career ?? ''}
+        links={(profile.links ?? []).map((link) => ({
+          title: link.title,
+          url: link.link,
+        }))}
+        profileImageUrl={profile.profileImage}
+        userId={userId}
+        profileId={profile.id}
+        chatButtonState={chatButtonState}
+        onChat={() => onChatRequest(profile.nickName)}
+        onMoveChat={handleMoveChat}
+      />
     </div>
   );
 };

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -99,7 +99,7 @@ const TestPage = () => {
   }
 
   return (
-    <div className="max-w-[1440px] m-auto">
+    <>
       <p className="text-2xl">현재 로그인 : {nickName}</p>
       <hr className="my-4" />
       <section>
@@ -188,7 +188,7 @@ const TestPage = () => {
           </ul>
         )}
       </section>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/profile/layout/ProfileLayout.tsx
+++ b/src/pages/profile/layout/ProfileLayout.tsx
@@ -1,14 +1,9 @@
 import { Outlet } from 'react-router-dom';
 import OnboardingContents from '@/components/profile/OnboardingContents.tsx';
-import Logo from '@/assets/images/logo.svg';
 
 const ProfileLayout = () => {
   return (
     <div className="flex flex-col min-h-screen overflow-hidden">
-      <nav className="h-[64px] flex items-center px-4 shrink-0">
-        <img src={Logo} alt="Logo" className="h-[40px]" />
-      </nav>
-
       <div
         className="flex w-full overflow-hidden"
         style={{ height: 'calc(100vh - 64px)' }}>


### PR DESCRIPTION
## Summary

>- closes #98

전체 페이지에 적용될 공통 레이아웃 컴포넌트를 설정합니다.

## Tasks
- 페이지별로 헤더 컴포넌트를 분리하여 적용
- 공통으로 사용되던 fixed, top-0, bg-black 등의 중복 스타일을 제거하고 `<Layout/>`에서 통합 관리하도록 수정
- 헤더 내 로고 영역에 웹 접근성을 고려하여 `<h1>` 태그를 사용하도록 변경

## To Reviewer
현재 헤더는 pc,mobild `fixed`로 설정되어 있어서, 레이아웃 상단에 고정되며
그에 따라 콘텐츠 영역에는 헤더 높이만큼의 여백을 고정값으로 설정해두었습니다.

다만, 실제 페이지마다 디자인상 간격이 조금씩 다를 수 있기 때문에
헤더와 콘텐츠 간 여백은 각 페이지에서 개별적으로 조정해주시는게 좋을 것 같습니다!
나중에 수정 필요하시면 말씀주세요!
