### PR TITLE
[feat] 채팅 메시지 입력 시 자동으로 하단 스크롤 이동 기능 구현

### DIFF
--- a/src/components/chatting/ChatRoom.tsx
+++ b/src/components/chatting/ChatRoom.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSocketStore } from '@/stores/useSocketStore';
 import { useChatMessageStore } from '@/stores/useChatMessageStore';
 import ChatProfileInfo from '@/components/chatting/ChatProfileInfo';
@@ -15,10 +15,15 @@ interface ChatRoomProps {
 }
 
 const ChatRoom = ({ room, onExpandMessage }: ChatRoomProps) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   const { stompClient } = useSocketStore();
   const { userId, nickName } = useChatMyInfo();
-  const { appendMessage, setMessages, clearMessages } = useChatMessageStore();
+  const { appendMessage, setMessages, clearMessages, messagesByRoom } =
+    useChatMessageStore();
   const { updateLastMessage } = useChatListStore();
+
+  const messages = room ? messagesByRoom[room.roomId] || [] : [];
 
   // 이전 메시지 불러오기
   useEffect(() => {
@@ -35,6 +40,15 @@ const ChatRoom = ({ room, onExpandMessage }: ChatRoomProps) => {
 
     fetchMessages();
   }, [room?.roomId, userId, setMessages]);
+
+  // 이전 메세지 불러온 뒤 하단 이동
+  useEffect(() => {
+    if (!scrollRef.current) return;
+
+    scrollRef.current.scrollTo({
+      top: scrollRef.current.scrollHeight,
+    });
+  }, [messages.length]);
 
   useEffect(() => {
     if (!room || !stompClient || !stompClient.connected) return;
@@ -73,7 +87,9 @@ const ChatRoom = ({ room, onExpandMessage }: ChatRoomProps) => {
 
   return (
     <>
-      <div className="relative flex flex-col flex-auto p-5 overflow-y-auto scrollbar-hide">
+      <div
+        ref={scrollRef}
+        className="relative flex flex-col flex-auto p-5 overflow-y-auto scrollbar-hide">
         <ChatProfileInfo otherId={otherId} />
         <div className="flex flex-col pt-5">
           <ChatMessageItem

--- a/src/components/chatting/ChatSideBar.tsx
+++ b/src/components/chatting/ChatSideBar.tsx
@@ -12,7 +12,7 @@ const ChatSideBar = ({ onClose, onLeaveConfirmCheck }: ChatSideBarProps) => {
         className="fixed z-10 top-0 inset-0 bg-black bg-opacity-70"
         onClick={onClose}
       />
-      <div className="absolute z-50 top-0 right-0 w-[175px] h-full text-left bg-[#141415]">
+      <div className="absolute z-30 top-0 right-0 w-[175px] h-full text-left bg-[#141415]">
         <p className="pt-[16px] px-[20px] pb-[8px] text-sm text-[#A2A4AA] font-semibold">
           채팅 메뉴
         </p>


### PR DESCRIPTION
## Summary

>- closes #108 

사용자가 채팅 메시지를 입력하거나 새 메시지를 수신했을 때, 채팅창이 자동으로 최신 메시지 위치로 스크롤되도록 처리합니다.

## Tasks
- 메시지 전송 시 자동 스크롤 기능 구현
- 채팅방 진입 시 기존 메시지가 있다면 하단으로 스크롤되도록 처리

## To Reviewer
시간 관계상 현재는 상대방 메시지 수신 시에는 스크롤이 같이 이동합니다.
스크롤 동작 조건이나 방식에 대해 수정이 필요하면 추후에 수정할 예정입니다.

