### PR TITLE
[feat] 채팅 실시간 메시지 알림, 안읽은 표시, 읽음 처리 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ export default function App() {
         </Routes>
 
         <ToastContainer
-          position="top-right"
+          position="top-left"
           autoClose={1500}
           hideProgressBar={true}
           closeOnClick
@@ -70,7 +70,7 @@ export default function App() {
           icon={false}
           closeButton={false}
           toastClassName={() =>
-            'rounded-sm border border-[#5A5C63] bg-[#262627] text-sm px-4 py-3 shadow-none'
+            'mt-4 ml-4 !w-[calc(100%-2rem)] tablet:!w-[300px] tablet:!mt-0 tablet:!ml-0 desktop:!mt-0 desktop:ml-0 cursor-pointer rounded-sm border border-[#5A5C63] bg-[#262627] text-sm px-4 py-3 shadow-none'
           }
         />
       </Router>

--- a/src/components/chatting/ChatListItem.tsx
+++ b/src/components/chatting/ChatListItem.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useState } from 'react';
 import { useUserProfile } from '@/hooks/useUserProfile';
 import { useChatMyInfo } from '@/stores/useChatMyInfoStore';
 import { ChatRoomType } from '@/types/chatRoomType';
 import { formatTime } from '@/utils/chat/formatTime';
-import { api } from '@/utils/api';
 
 interface ChatListItemProps {
   room: ChatRoomType;
@@ -11,9 +9,7 @@ interface ChatListItemProps {
 }
 
 const ChatListItem = ({ room, onClick }: ChatListItemProps) => {
-  const [unreadCount, setUnreadCount] = useState(0);
-
-  const { participants, lastMessage, lastMessageTime } = room;
+  const { participants, lastMessage, lastMessageTime, unreadCount } = room;
 
   const { profile } = useUserProfile(room.otherId);
   const { nickName } = useChatMyInfo();
@@ -21,24 +17,6 @@ const ChatListItem = ({ room, onClick }: ChatListItemProps) => {
   const otherUser = participants.find(
     (userNickname) => userNickname !== nickName,
   );
-
-  // 임시 테스트 코드
-  useEffect(() => {
-    const fetchUnreadCount = async () => {
-      try {
-        const response = await api.get<{ unreadCount: number }>(
-          `/api/chat/${room.roomId}/unread-count?clientId=${room.otherId}`,
-        );
-        setUnreadCount(response.data.unreadCount);
-
-        console.log(response.data.unreadCount);
-      } catch (err) {
-        console.error('unread-count 가져오기 실패:', err);
-      }
-    };
-
-    fetchUnreadCount();
-  }, [room.roomId, room.otherId]);
 
   return (
     <li

--- a/src/stores/useSocketStore.ts
+++ b/src/stores/useSocketStore.ts
@@ -13,7 +13,7 @@ export const useSocketStore = create<StompState>((set, get) => ({
   stompClient: null,
   isConnected: false,
 
-  connect: () => {
+  connect: (onConnected) => {
     console.log('웹소켓 연결 시도 중');
 
     const client = new Client({
@@ -24,6 +24,7 @@ export const useSocketStore = create<StompState>((set, get) => ({
       reconnectDelay: 5000,
       onConnect: () => {
         set({ isConnected: true });
+        if (onConnected) onConnected();
       },
       onStompError: (frame) => {
         console.error('STOMP 오류', frame);


### PR DESCRIPTION
## Summary

>- closes #142  

실시간 메시지 알림, 안 읽은 메시지 인디케이터, 메시지 읽음 처리 기능을 구현했습니다.

## Tasks

- 채팅방별 안 읽은 메시지 개수 표시
- 내가 보낸 메시지에 대해서는 unreadCount 증가하지 않도록 처리
- 채팅방 입장 시 해당 방의 unreadCount를 0으로 초기화 (읽음 처리)
- WebSocket을 통한 실시간 메시지 알림 구독 기능 추가
