### PR TITLE
[refactor] 채팅 기능에서 nickname 참조를 clientId로 일괄 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,6 @@
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0",
     "vite-tsconfig-paths": "^5.1.4"
-  }
+  },
+  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }

--- a/src/hooks/useChatRequest.ts
+++ b/src/hooks/useChatRequest.ts
@@ -2,8 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 import { api } from '@/utils/api';
 
 interface ChatRequestPayload {
-  senderNickname: string;
-  receiverNickname: string;
+  senderId: number;
+  receiverId: number;
 }
 
 export const useChatRequest = () => {

--- a/src/hooks/useChatRequestFetch.ts
+++ b/src/hooks/useChatRequestFetch.ts
@@ -5,31 +5,32 @@ import {
 } from '@/services/chatRequestListApi';
 import { useChatRequestStore } from '@/stores/useChatRequestStore';
 
-export const useChatRequestFetch = (currentUser: string) => {
-  const enabled = !!currentUser;
+export const useChatRequestFetch = (currentUser: string, senderId: number) => {
+  const senderEnabled = !isNaN(senderId);
+  const receiverEnabled = !!currentUser;
 
   useQuery({
-    queryKey: ['chatSentList', currentUser, 'PENDING'],
+    queryKey: ['chatSentList', senderId, 'PENDING'],
     queryFn: async () => {
-      const data = await fetchChatSentList(currentUser, 'PENDING');
+      const data = await fetchChatSentList(senderId, 'PENDING');
       useChatRequestStore
         .getState()
         .setChatRequests('sent', 'PENDING', Array.isArray(data) ? data : []);
       return data;
     },
-    enabled,
+    enabled: senderEnabled,
   });
 
   useQuery({
-    queryKey: ['chatSentList', currentUser, 'ACCEPTED'],
+    queryKey: ['chatSentList', senderId, 'ACCEPTED'],
     queryFn: async () => {
-      const data = await fetchChatSentList(currentUser, 'ACCEPTED');
+      const data = await fetchChatSentList(senderId, 'ACCEPTED');
       useChatRequestStore
         .getState()
         .setChatRequests('sent', 'ACCEPTED', Array.isArray(data) ? data : []);
       return data;
     },
-    enabled,
+    enabled: senderEnabled,
   });
 
   useQuery({
@@ -45,7 +46,7 @@ export const useChatRequestFetch = (currentUser: string) => {
         );
       return data;
     },
-    enabled,
+    enabled: receiverEnabled,
   });
 
   useQuery({
@@ -61,6 +62,6 @@ export const useChatRequestFetch = (currentUser: string) => {
         );
       return data;
     },
-    enabled,
+    enabled: receiverEnabled,
   });
 };

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -34,9 +34,9 @@ const ChatPage = () => {
   );
 
   const { isLoading, error } = useQuery({
-    queryKey: ['chatList', nickName, selectedOption],
+    queryKey: ['chatList', userId, selectedOption],
     queryFn: async () => {
-      const data = await fetchChatListApi(nickName ?? '', selectedOption.value);
+      const data = await fetchChatListApi(userId || 0, selectedOption.value);
 
       // 읽음 처리된 상태로 먼저 필터링
       const filtered = data.map((room) => {

--- a/src/pages/ProfilePreviewPage.tsx
+++ b/src/pages/ProfilePreviewPage.tsx
@@ -29,25 +29,25 @@ const ProfilePreviewPage = () => {
       req.receiverNickname === profile?.nickName,
   );
 
-  const handleMoveChat = () => {
+  const handleMoveChat = async () => {
     if (acceptedChat) {
-      chatRoomRequestId(acceptedChat.id, navigate);
+      await chatRoomRequestId(acceptedChat.id, navigate);
     }
   };
 
   // 채팅 요청
   const { mutate: chatRequest } = useChatRequest();
-  const onChatRequest = (receiverNickname: string) => {
-    if (!nickName) return;
+  const onChatRequest = () => {
+    if (!userId || !profile?.id) return;
 
     chatRequest(
-      { senderNickname: nickName, receiverNickname },
+      { senderId: userId, receiverId: profile.id },
       {
-        onSuccess: () => {
-          toast.success(`${receiverNickname}님에게 요청을 보냈습니다.`);
+        onSuccess: async () => {
+          toast.success(`${profile.nickName}님에게 요청을 보냈습니다.`);
 
-          queryClient.invalidateQueries({
-            queryKey: ['chatSentList', nickName, 'PENDING'],
+          await queryClient.invalidateQueries({
+            queryKey: ['chatSentList', userId, 'PENDING'],
           });
         },
       },
@@ -88,7 +88,7 @@ const ProfilePreviewPage = () => {
         userId={userId}
         profileId={profile.id}
         chatButtonState={chatButtonState}
-        onChat={() => onChatRequest(profile.nickName)}
+        onChat={() => onChatRequest}
         onMoveChat={handleMoveChat}
       />
     </div>

--- a/src/pages/ProfilePreviewPage.tsx
+++ b/src/pages/ProfilePreviewPage.tsx
@@ -21,7 +21,7 @@ const ProfilePreviewPage = () => {
   const { sent, received } = useChatRequestStore();
   const { userId, nickName } = useChatMyInfo();
 
-  useChatRequestFetch(nickName ?? '');
+  useChatRequestFetch(nickName ?? '', userId ?? NaN);
 
   const acceptedChat = [...sent.ACCEPTED, ...received.ACCEPTED].find(
     (req) =>

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -37,17 +37,17 @@ const TestPage = () => {
 
   // 채팅 요청
   const { mutate: chatRequest } = useChatRequest();
-  const onChatRequest = (receiverNickname: string) => {
-    if (!nickName) return;
+  const onChatRequest = (receiverId: number, receiverNickname: string) => {
+    if (!userId) return;
 
     chatRequest(
-      { senderNickname: nickName, receiverNickname },
+      { senderId: userId, receiverId },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
           toast.success(`${receiverNickname}님에게 요청을 보냈습니다.`);
 
-          queryClient.invalidateQueries({
-            queryKey: ['chatSentList', nickName, 'PENDING'],
+          await queryClient.invalidateQueries({
+            queryKey: ['chatSentList', userId, 'PENDING'],
           });
         },
       },
@@ -58,7 +58,7 @@ const TestPage = () => {
   const { mutate: acceptRequest } = useAcceptRequest();
   const onChatAccept = (req: ChatRequestType) => {
     acceptRequest(req.id, {
-      onSuccess: (data) => {
+      onSuccess: async (data) => {
         toast.success(`${req.senderNickname}님의 요청을 수락했습니다.`, {
           autoClose: 0.5,
         });
@@ -69,7 +69,7 @@ const TestPage = () => {
           }
         }, 600);
 
-        queryClient.invalidateQueries({
+        await queryClient.invalidateQueries({
           queryKey: ['chatReceivedList', nickName, 'PENDING'],
         });
       },
@@ -80,10 +80,10 @@ const TestPage = () => {
   const { mutate: rejectRequest } = useRejectRequest();
   const onChatReject = (req: ChatRequestType) => {
     rejectRequest(req.id, {
-      onSuccess: () => {
+      onSuccess: async () => {
         toast.success(`${req.senderNickname}님의 요청을 거절했습니다.`);
 
-        queryClient.invalidateQueries({
+        await queryClient.invalidateQueries({
           queryKey: ['chatReceivedList', nickName, 'PENDING'],
         });
       },
@@ -141,7 +141,7 @@ const TestPage = () => {
                 {state === 'REQUEST' && (
                   <Button
                     size="sm"
-                    onClick={() => onChatRequest(user.nickName)}>
+                    onClick={() => onChatRequest(user.id, user.nickName)}>
                     대화 요청하기
                   </Button>
                 )}

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -24,10 +24,10 @@ const fetchUsers = async () => {
 const TestPage = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { nickName, isLoading } = useChatMyInfo();
+  const { userId, nickName, isLoading } = useChatMyInfo();
   const { sent, received } = useChatRequestStore();
 
-  useChatRequestFetch(nickName ?? '');
+  useChatRequestFetch(nickName ?? '', userId ?? NaN);
 
   // 참가자 조회
   const { data: users = [] } = useQuery<UserProfileType[]>({

--- a/src/services/chatListApi.ts
+++ b/src/services/chatListApi.ts
@@ -2,14 +2,14 @@ import { api } from '@/utils/api';
 import { ChatRoomType } from '@/types/chatRoomType';
 
 export const fetchChatListApi = async (
-  nickname: string,
+  clientId: number,
   sortBy: 'latest' | 'unread',
 ): Promise<ChatRoomType[]> => {
   const endpoint =
     sortBy === 'latest' ? '/api/chat/latest' : '/api/chat/unread';
 
   const res = await api.get(endpoint, {
-    params: { nickname },
+    params: { clientId },
   });
 
   const data: ChatRoomType[] = res.data;

--- a/src/services/chatRequestListApi.ts
+++ b/src/services/chatRequestListApi.ts
@@ -3,12 +3,12 @@ import { ChatRequestType } from '@/types/chatRequestType';
 
 // 보낸 요청 호출
 export const fetchChatSentList = async (
-  nickname: string,
+  senderId: number,
   status: 'PENDING' | 'ACCEPTED',
 ): Promise<ChatRequestType[]> => {
   const response = await api.get(`/api/chat/request/sent`, {
     params: {
-      senderNickname: nickname,
+      senderId,
       status,
     },
   });


### PR DESCRIPTION
## Summary

마이페이지에서 사용자가 닉네임을 수정할 수 있도록 기능 구현.
하지만 기존에 닉네임을 참조하고 있던 chat_room, chat_message 등 레코드들이 
이전 닉네임을 기준으로 연결되어 있어 일부 기능에서 오류 발생 가능성 확인됨.

## Tasks
- 닉네임 대신 유저 ID를 참조하도록 변경

## To Reviewer
테스트 환경상 문제시 재진행하겠습니다🥲


