### PR TITLE
[fix] 채팅 기능에서 clientId 참조 오류 수정

### DIFF
--- a/src/components/chatting/ChatInput.tsx
+++ b/src/components/chatting/ChatInput.tsx
@@ -8,10 +8,11 @@ import { useChatListStore } from '@/stores/useChatListStore';
 interface ChatInputProps {
   roomId: number;
   socketRef: { current: Client | null };
+  senderId: number;
   nickName: string;
 }
 
-const ChatInput = ({ roomId, socketRef, nickName }: ChatInputProps) => {
+const ChatInput = ({ roomId, socketRef, nickName, senderId }: ChatInputProps) => {
   const [message, setMessage] = useState('');
   const maxLength = 1000;
 
@@ -38,6 +39,7 @@ const ChatInput = ({ roomId, socketRef, nickName }: ChatInputProps) => {
     const chatMessage: ChatMessageType = {
       messageId: Date.now(),
       roomId,
+      senderId,
       senderNickname: nickName,
       content: trimmed,
       timeStamp: new Date().toISOString(),

--- a/src/components/chatting/ChatRoom.tsx
+++ b/src/components/chatting/ChatRoom.tsx
@@ -144,6 +144,7 @@ const ChatRoom = ({ room, onExpandMessage }: ChatRoomProps) => {
       <ChatInput
         roomId={room.roomId}
         nickName={nickName ?? ''}
+        senderId={userId || 0}
         socketRef={{ current: stompClient }}
       />
     </>

--- a/src/types/chatMessageType.ts
+++ b/src/types/chatMessageType.ts
@@ -1,6 +1,7 @@
 export interface ChatMessageType {
   messageId?: number;
   roomId: number;
+  senderId: number;
   senderNickname: string | null;
   content: string;
   type: 'JOIN' | 'CHAT' | 'LEAVE';


### PR DESCRIPTION
## Summary

>- #164 

채팅 기능에서 clientId 참조 오류를 수정했습니다.

## Tasks

- 채팅 메시지에 senderId 필드 추가
- 프론트에서 senderId를 활용할 수 있도록 구조 반영

## To Reviewer
테스트 환경상 문제 발생 시 재진행하겠습니다.


