### PR TITLE
[fix] 읽음 처리 기능 오류 2

### DIFF
--- a/src/components/chatting/ChatInput.tsx
+++ b/src/components/chatting/ChatInput.tsx
@@ -54,7 +54,7 @@ const ChatInput = ({ roomId, socketRef, nickName, senderId }: ChatInputProps) =>
 
     // 상태 반영
     appendMessage(roomId, chatMessage);
-    updateLastMessage(roomId, chatMessage, nickName);
+    updateLastMessage(roomId, chatMessage, senderId);
 
     setMessage('');
 

--- a/src/components/chatting/ChatRoom.tsx
+++ b/src/components/chatting/ChatRoom.tsx
@@ -100,7 +100,7 @@ const ChatRoom = ({ room, onExpandMessage }: ChatRoomProps) => {
         const newMessage = JSON.parse(message.body);
 
         appendMessage(room.roomId, newMessage);
-        updateLastMessage(room.roomId, newMessage, nickName ?? '');
+        updateLastMessage(room.roomId, newMessage, userId || 0);
       },
     );
 

--- a/src/stores/useChatListStore.ts
+++ b/src/stores/useChatListStore.ts
@@ -13,7 +13,7 @@ interface ChatListState {
   updateLastMessage: (
     roomId: number,
     lastMessage: ChatMessageType,
-    currentUser: string,
+    currentUserId: number,
   ) => void;
 
   increaseUnreadCount: (roomId: number) => void;
@@ -35,12 +35,12 @@ export const useChatListStore = create<ChatListState>((set) => ({
   updateLastMessage: (
     roomId: number,
     lastMessage: ChatMessageType,
-    currentUser: string,
+    currentUserId: number,
   ) =>
     set((state) => ({
       chatList: state.chatList.map((room) => {
         if (room.roomId === roomId) {
-          const isSenderMe = lastMessage.senderNickname === currentUser;
+          const isSenderMe = lastMessage.senderId === currentUserId;
 
           return {
             ...room,


### PR DESCRIPTION
## Summary

>- #170 

채팅방 읽음 처리 로직에서 닉네임(senderNickname) 대신 유저 고유 ID(senderId)로 수정하지 못했던 부분을 추가로 보완했습니다.

## Tasks

-`updateLastMessage` 함수에서 사용자 식별을 senderId 기준으로 처리

## To Reviewer

테스트 환경상 문제 발생 시, 추가 수정 및 재진행 예정입니다.

