### PR TITLE
[fix] 상대방 닉네임 판별 로직에 필요한 필드 추가

### DIFF
--- a/src/components/chatting/ChatInput.tsx
+++ b/src/components/chatting/ChatInput.tsx
@@ -10,9 +10,10 @@ interface ChatInputProps {
   socketRef: { current: Client | null };
   senderId: number;
   nickName: string;
+  recipientNickname: string;
 }
 
-const ChatInput = ({ roomId, socketRef, nickName, senderId }: ChatInputProps) => {
+const ChatInput = ({ roomId, socketRef, nickName, senderId, recipientNickname  }: ChatInputProps) => {
   const [message, setMessage] = useState('');
   const maxLength = 1000;
 
@@ -41,6 +42,7 @@ const ChatInput = ({ roomId, socketRef, nickName, senderId }: ChatInputProps) =>
       roomId,
       senderId,
       senderNickname: nickName,
+      recipientNickname,
       content: trimmed,
       timeStamp: new Date().toISOString(),
       type: 'CHAT',

--- a/src/components/chatting/ChatRoom.tsx
+++ b/src/components/chatting/ChatRoom.tsx
@@ -146,6 +146,9 @@ const ChatRoom = ({ room, onExpandMessage }: ChatRoomProps) => {
         nickName={nickName ?? ''}
         senderId={userId || 0}
         socketRef={{ current: stompClient }}
+        recipientNickname={
+          room.participants.find((name) => name !== nickName) ?? ''
+        }
       />
     </>
   );

--- a/src/types/chatMessageType.ts
+++ b/src/types/chatMessageType.ts
@@ -3,6 +3,7 @@ export interface ChatMessageType {
   roomId: number;
   senderId: number;
   senderNickname: string | null;
+  recipientNickname: string;
   content: string;
   type: 'JOIN' | 'CHAT' | 'LEAVE';
   timeStamp?: string;


### PR DESCRIPTION
## Summary

>- #170 
읽음 처리 문제를 해결하기 위해 채팅방 입장 시 상대방 닉네임 판별 로직에 필요한 필드를 추가했습니다.

## Tasks

- `ChatMessageType`에 `recipientNickname` 필드 추가
- `ChatInpu`t에서 상대방 닉네임을 전달하고 메시지 생성 시 포함

## To Reviewer

현재 테스트 환경상 문제시 재진행하겠습니다.

