### PR TITLE
[fix] 웹소켓 연결 시 connectHeaders로 roomId, userId, nickname 전달

### DIFF
--- a/src/components/chatting/ChatInput.tsx
+++ b/src/components/chatting/ChatInput.tsx
@@ -13,7 +13,7 @@ interface ChatInputProps {
   recipientNickname: string;
 }
 
-const ChatInput = ({ roomId, socketRef, nickName, senderId, recipientNickname  }: ChatInputProps) => {
+const ChatInput = ({ roomId, socketRef, nickName, senderId, recipientNickname }: ChatInputProps) => {
   const [message, setMessage] = useState('');
   const maxLength = 1000;
 

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -78,9 +78,10 @@ const ChatPage = () => {
   
   //
   useEffect(() => {
-    if (!isConnected && nickName) {
-      connect(() => {
+    if (!isConnected && nickName && userId && selectedRoom?.roomId) {
+      connect(userId, nickName, selectedRoom.roomId, () => {
         const client = useSocketStore.getState().stompClient;
+
         if (client) {
           client.subscribe(
             `/queue/chat-notification/${nickName}`,
@@ -134,8 +135,8 @@ const ChatPage = () => {
         }
       });
     }
-  }, [connect, isConnected, nickName]);
-
+  }, [connect, isConnected, nickName, userId, selectedRoom?.roomId]);
+  
   useEffect(() => {
     if (chatList.length > 0 && roomId && !isLoading) {
       const room = chatList.find((room) => room.roomId === roomId);

--- a/src/stores/useSocketStore.ts
+++ b/src/stores/useSocketStore.ts
@@ -5,7 +5,12 @@ import SockJS from 'sockjs-client';
 interface StompState {
   stompClient: Client | null;
   isConnected: boolean;
-  connect: (onConnected?: () => void) => void;
+  connect: (
+    userId: number,
+    nickName: string,
+    roomId: number,
+    onConnected?: () => void,
+  ) => void;
   disconnect: () => void;
 }
 
@@ -13,12 +18,17 @@ export const useSocketStore = create<StompState>((set, get) => ({
   stompClient: null,
   isConnected: false,
 
-  connect: (onConnected) => {
+  connect: (userId, nickName, roomId, onConnected) => {
     console.log('웹소켓 연결 시도 중');
 
     const client = new Client({
       webSocketFactory: () => {
         return new SockJS(import.meta.env.VITE_WS_CHAT_URL);
+      },
+      connectHeaders: {
+        roomId: String(roomId),
+        clientId: String(userId),
+        senderNickname: nickName,
       },
       debug: (str) => console.log('[STOMP DEBUG]', str),
       reconnectDelay: 5000,


### PR DESCRIPTION
## Summary

>- #170 
웹소켓 연결 시 클라이언트의 `roomId`, `userId`, `nickname` 정보를 `connectHeaders`를 통해 서버에 함께 전달하도록 수정했습니다.
서버에서 사용자 식별 및 채팅방 컨텍스트를 초기부터 정확히 파악할 수 있게 됩니다.

## Tasks

- socketStore에서 STOMP client 초기화 시 `connectHeaders` 추가
- header에 `roomId`, `clientId`, `senderNickname` 포함

