### PR TITLE
[fix] useChatRequestRealtime 호출 시 인자 누락 오류 수정

### DIFF
--- a/src/components/location/BottomSheet.tsx
+++ b/src/components/location/BottomSheet.tsx
@@ -20,14 +20,13 @@ import { getChatButtonState } from '@/utils/chat/getChatButtonState';
 import { useChatRequestRealtime } from '@/hooks/useChatRequestRealtime';
 
 const BottomSheet: React.FC = () => {
-  const { nickName } = useChatMyInfo();
-  useChatRequestRealtime(nickName ?? '');
+  const { userId, nickName } = useChatMyInfo();
+  useChatRequestRealtime(userId || 0, nickName ?? '');
+
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-
-  const { userId } = useChatMyInfo();
 
   const { sent, received } = useChatRequestStore();
 

--- a/src/hooks/useChatRequestRealtime.ts
+++ b/src/hooks/useChatRequestRealtime.ts
@@ -5,7 +5,10 @@ import { useUserStore } from '@/stores/useUserStore';
 import { toast } from 'react-toastify';
 import { useLocation } from 'react-router-dom';
 
-export const useChatRequestRealtime = (nickName: string) => {
+export const useChatRequestRealtime = (
+  userId: number,
+  nickName: string,
+) => {
   const { connect, isConnected } = useSocketStore();
   const users = useUserStore((state) => state.users);
   const location = useLocation();
@@ -13,7 +16,7 @@ export const useChatRequestRealtime = (nickName: string) => {
   useEffect(() => {
     if (!nickName) return;
     if (!isConnected) {
-      connect();
+      connect(userId, nickName);
     }
 
     const interval = setInterval(() => {

--- a/src/stores/useSocketStore.ts
+++ b/src/stores/useSocketStore.ts
@@ -8,7 +8,7 @@ interface StompState {
   connect: (
     userId: number,
     nickName: string,
-    roomId: number,
+    roomId?: number,
     onConnected?: () => void,
   ) => void;
   disconnect: () => void;


### PR DESCRIPTION
## Summary

>- #176 

`useChatRequestRealtime` 훅은 현재 최소 3개의 인자를 요구하지만, 
일부 컴포넌트에서 해당 훅을 호출할 때 인자를 전달하지 않아 TypeScript 오류가 발생했습니다. 
필요한 인자들이 올바르게 전달되도록 수정하여 오류를 해결했습니다.

## Tasks

- useChatRequestRealtime 훅이 호출되는 컴포넌트에서 누락된 인자를 추가했습니다.
- roomId는 사용되지 않는 경우 optional 처리

